### PR TITLE
Fix group messaging and document usage

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,0 +1,12 @@
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+WORKDIR /workspace
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q -DskipTests package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /workspace/target/socket-chat-0.0.1-SNAPSHOT-client.jar /app/socket-client.jar
+ENV CHAT_SERVER_HOST=localhost \
+    CHAT_SERVER_PORT=12345
+ENTRYPOINT ["java","-jar","/app/socket-client.jar"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,11 @@
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+WORKDIR /workspace
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q -DskipTests package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /workspace/target/socket-chat-0.0.1-SNAPSHOT.jar /app/socket-server.jar
+EXPOSE 12345
+ENTRYPOINT ["java","-jar","/app/socket-server.jar"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,118 @@
+# Socket Chat
+
+Socket Chat é uma aplicação de chat distribuído composta por um servidor TCP e um cliente de linha de comando. O projeto foi migrado para o ecossistema Spring Boot para permitir injeção de dependências e facilitar a configuração dos componentes principais do servidor, mantendo toda a comunicação baseada em sockets.
+
+## Arquitetura
+
+- **Servidor** (`SocketServerChatApplication`)
+  - Mantém um `ServerSocket` escutando a porta `12345`.
+  - Cada nova conexão cria um `ChatHandler` (escopo *prototype*) injetado com `SessionManager`, `ChatService` e `GroupService`.
+  - Permite mensagens privadas, criação/entrada/saída de grupos e entrega de arquivos.
+  - Armazena mensagens offline através de `OfflineMessageStorage` quando o destinatário está desconectado.
+- **Cliente** (`ChatClientApplication`)
+  - CLI interativa que envia comandos e mensagens ao servidor.
+  - Resolve `CHAT_SERVER_HOST` e `CHAT_SERVER_PORT` via variáveis de ambiente ou propriedades do sistema para facilitar execução em contêiner.
+
+## Pré-requisitos
+
+- Java 21+
+- Maven 3.9+ (ou o *wrapper* `./mvnw`)
+- Docker 24+ e Docker Compose 2+ (opcional, para execução containerizada)
+
+## Como executar localmente
+
+### 1. Compilar o projeto
+
+```bash
+./mvnw clean package
+```
+
+> **Observação:** o wrapper fará download das dependências do Maven na primeira execução. Caso esteja sem acesso à internet, use um cache local ou configure um mirror acessível.
+
+### 2. Iniciar o servidor
+
+```bash
+java -jar target/socket-chat-0.0.1-SNAPSHOT.jar
+```
+
+### 3. Iniciar um cliente CLI
+
+Em outro terminal, execute:
+
+```bash
+java -jar target/socket-chat-0.0.1-SNAPSHOT-client.jar
+```
+
+Informe um nome de usuário quando solicitado e utilize os comandos `/help`, `/msg`, `/groups`, `/join`, entre outros, para interagir.
+
+## Execução com Docker
+
+O projeto inclui Dockerfiles dedicados para servidor e cliente, além de um `docker-compose.yml` para orquestração.
+
+### 1. Construir e subir o servidor
+
+```bash
+docker compose up -d --build server
+```
+
+### 2. Abrir clientes interativos
+
+```bash
+docker compose run --rm client
+```
+
+Repita o comando acima em quantas janelas de terminal quiser para simular múltiplos usuários. Também é possível escalar clientes em segundo plano:
+
+```bash
+docker compose up --scale client=3
+```
+
+Depois conecte-se a cada contêiner em execução com `docker attach socket-chat-client-1`, `socket-chat-client-2`, etc. Use `Ctrl + P`, `Ctrl + Q` para se desanexar sem encerrar o processo.
+
+## Como testar
+
+1. **Testes unitários/integração**
+   ```bash
+   ./mvnw test
+   ```
+2. **Verificação de pacote executável**
+   ```bash
+   ./mvnw clean package
+   ```
+3. **Smoke test manual**
+   - Inicie o servidor localmente (`java -jar target/...jar`).
+   - Abra dois terminais com o cliente e verifique o envio/recebimento de mensagens privadas e em grupo.
+
+> Nos ambientes onde não há acesso à Maven Central, os comandos acima podem falhar no download das dependências. Nesses casos utilize um repositório local ou rode os testes em um ambiente com acesso à internet.
+
+## Comandos úteis no cliente
+
+- `/help` – Lista todos os comandos disponíveis.
+- `/msg <usuário> <mensagem>` – Envia mensagem privada.
+- `/groups` – Lista grupos disponíveis.
+- `/create <nome>` – Cria um novo grupo.
+- `/join <nome>` – Entra em um grupo existente.
+- `/leave <nome>` – Sai de um grupo.
+- `/file <usuário> <caminho>` – Envia arquivo privado.
+- `/quit` – Desconecta do servidor.
+
+## Estrutura de pastas
+
+```
+.
+├── Dockerfile.client
+├── Dockerfile.server
+├── docker-compose.yml
+├── pom.xml
+└── src
+    ├── main
+    │   ├── java
+    │   └── resources
+    └── test
+```
+
+O diretório `src/main/java/br/com/study/socketchat/server` contém todas as classes do servidor Spring Boot e `src/main/java/br/com/study/socketchat/client` contém o cliente CLI.
+
+## Licença
+
+Este projeto é fornecido para fins de estudo e pode ser utilizado conforme necessário.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.8"
+
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    ports:
+      - "12345:12345"
+    networks:
+      - chat-net
+
+  client:
+    build:
+      context: .
+      dockerfile: Dockerfile.client
+    environment:
+      CHAT_SERVER_HOST: server
+      CHAT_SERVER_PORT: 12345
+    stdin_open: true
+    tty: true
+    depends_on:
+      - server
+    networks:
+      - chat-net
+
+networks:
+  chat-net:
+    driver: bridge

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,26 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>br.com.study.socketchat.server.SocketServerChatApplication</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>client</id>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>client</classifier>
+                            <mainClass>br.com.study.socketchat.client.ChatClientApplication</mainClass>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/br/com/study/socketchat/client/ChatClientApplication.java
+++ b/src/main/java/br/com/study/socketchat/client/ChatClientApplication.java
@@ -20,8 +20,8 @@ import java.util.concurrent.Executors;
  */
 @SpringBootApplication
 public class ChatClientApplication {
-    private static final String SERVER_HOST = "localhost";
-    private static final int SERVER_PORT = 12345;
+    private static final String SERVER_HOST = resolveServerHost();
+    private static final int SERVER_PORT = resolveServerPort();
     private static final String DOWNLOADS_DIRECTORY = "client_downloads/";
 
     private Socket socket;
@@ -36,6 +36,40 @@ public class ChatClientApplication {
         this.executor = Executors.newSingleThreadExecutor();
         this.scanner = new Scanner(System.in);
         createDownloadsDirectory();
+    }
+
+    private static String resolveServerHost() {
+        String env = System.getenv("CHAT_SERVER_HOST");
+        if (env != null && !env.isBlank()) {
+            return env.trim();
+        }
+        String property = System.getProperty("chat.server.host");
+        if (property != null && !property.isBlank()) {
+            return property.trim();
+        }
+        return "localhost";
+    }
+
+    private static int resolveServerPort() {
+        String env = System.getenv("CHAT_SERVER_PORT");
+        if (env != null && !env.isBlank()) {
+            try {
+                return Integer.parseInt(env.trim());
+            } catch (NumberFormatException ex) {
+                System.out.println("CHAT_SERVER_PORT inválida: " + env + ". Usando porta padrão 12345.");
+            }
+        }
+
+        String property = System.getProperty("chat.server.port");
+        if (property != null && !property.isBlank()) {
+            try {
+                return Integer.parseInt(property.trim());
+            } catch (NumberFormatException ex) {
+                System.out.println("Propriedade chat.server.port inválida: " + property + ". Usando porta padrão 12345.");
+            }
+        }
+
+        return 12345;
     }
 
     private void createDownloadsDirectory() {

--- a/src/main/java/br/com/study/socketchat/server/ChatHandler.java
+++ b/src/main/java/br/com/study/socketchat/server/ChatHandler.java
@@ -9,6 +9,8 @@ import br.com.study.socketchat.server.service.ChatService;
 import br.com.study.socketchat.server.session.SessionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 import java.io.*;
 import java.net.Socket;
@@ -19,11 +21,13 @@ import java.util.List;
  * Handler para gerenciar a comunicação com um cliente específico
  * Cada cliente conectado tem sua própria thread com este handler
  */
+@Component
+@Scope("prototype")
 public class ChatHandler implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(ChatHandler.class);
     private static final String SERVER_USER = "SERVER";
 
-    private final Socket clientSocket;
+    private Socket clientSocket;
     private final SessionManager sessionManager;
     private final ChatService chatService;
     private final GroupService groupService;
@@ -32,15 +36,26 @@ public class ChatHandler implements Runnable {
     private String username;
     private boolean isConnected = true;
 
-    public ChatHandler(Socket clientSocket, SessionManager sessionManager, ChatService chatService, GroupService groupService) {
-        this.clientSocket = clientSocket;
+    public ChatHandler(SessionManager sessionManager, ChatService chatService, GroupService groupService) {
         this.sessionManager = sessionManager;
         this.chatService = chatService;
         this.groupService = groupService;
     }
 
+    public ChatHandler initialize(Socket clientSocket) {
+        this.clientSocket = clientSocket;
+        this.username = null;
+        this.isConnected = true;
+        this.inputStream = null;
+        this.outputStream = null;
+        return this;
+    }
+
     @Override
     public void run() {
+        if (clientSocket == null) {
+            throw new IllegalStateException("ChatHandler needs to be initialized with a client socket");
+        }
         try {
             outputStream = new ObjectOutputStream(clientSocket.getOutputStream());
             inputStream = new ObjectInputStream(clientSocket.getInputStream());
@@ -151,7 +166,7 @@ public class ChatHandler implements Runnable {
         for (Group group : groups) {
             stringBuilder.append(group.toString()).append("\n");
         }
-        sendGenericMessage(new Message(MessageType.USERS_LIST, SERVER_USER, username, stringBuilder.toString()));
+        sendGenericMessage(new Message(MessageType.GROUPS_LIST, SERVER_USER, username, stringBuilder.toString()));
     }
 
     private void createGroup(Message message) {

--- a/src/main/java/br/com/study/socketchat/server/ChatHandlerFactory.java
+++ b/src/main/java/br/com/study/socketchat/server/ChatHandlerFactory.java
@@ -1,0 +1,20 @@
+package br.com.study.socketchat.server;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+import java.net.Socket;
+
+@Component
+public class ChatHandlerFactory {
+
+    private final ObjectProvider<ChatHandler> chatHandlerProvider;
+
+    public ChatHandlerFactory(ObjectProvider<ChatHandler> chatHandlerProvider) {
+        this.chatHandlerProvider = chatHandlerProvider;
+    }
+
+    public ChatHandler create(Socket socket) {
+        return chatHandlerProvider.getObject().initialize(socket);
+    }
+}

--- a/src/main/java/br/com/study/socketchat/server/SocketServerChatApplication.java
+++ b/src/main/java/br/com/study/socketchat/server/SocketServerChatApplication.java
@@ -1,18 +1,19 @@
 package br.com.study.socketchat.server;
 
-
-import br.com.study.socketchat.server.group.GroupManager;
 import br.com.study.socketchat.server.group.service.GroupService;
 import br.com.study.socketchat.server.service.ChatService;
 import br.com.study.socketchat.server.session.SessionManager;
-import br.com.study.socketchat.server.storage.OfflineMessageStorage;
-import br.com.study.socketchat.server.storage.impl.OfflineMessageStorageImpl;
+import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import java.io.*;
-import java.net.*;
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -21,85 +22,97 @@ import java.util.concurrent.Executors;
  * Suporta mensagens privadas, grupos e envio de arquivos
  */
 @SpringBootApplication
-public class SocketServerChatApplication {
+public class SocketServerChatApplication implements CommandLineRunner {
 
     private static final int PORT = 12345;
     private static final String FILES_DIRECTORY = "server_files/";
 
-    private ServerSocket serverSocket;
-    private boolean isRunning = false;
-    private ExecutorService threadPool;
-    
-    private final OfflineMessageStorage offlineMessageStorage;
+    private static final Logger LOG = LoggerFactory.getLogger(SocketServerChatApplication.class);
+
     private final SessionManager sessionManager;
     private final ChatService chatService;
-    private final GroupManager groupManager;
     private final GroupService groupService;
+    private final ChatHandlerFactory chatHandlerFactory;
+    private final ExecutorService threadPool = Executors.newCachedThreadPool();
 
+    private ServerSocket serverSocket;
+    private boolean isRunning = false;
 
-    public SocketServerChatApplication() {
-        this.threadPool = Executors.newCachedThreadPool();
-        this.sessionManager = new SessionManager();
-        this.offlineMessageStorage = new OfflineMessageStorageImpl();
-        this.groupManager =  new GroupManager();
-        this.groupService = new GroupService(groupManager);
-        this.chatService = new ChatService(sessionManager, groupService, offlineMessageStorage);
-
+    public SocketServerChatApplication(SessionManager sessionManager,
+                                       ChatService chatService,
+                                       GroupService groupService,
+                                       ChatHandlerFactory chatHandlerFactory) {
+        this.sessionManager = sessionManager;
+        this.chatService = chatService;
+        this.groupService = groupService;
+        this.chatHandlerFactory = chatHandlerFactory;
         createFilesDirectory();
     }
-    
+
     private void createFilesDirectory() {
         File dir = new File(FILES_DIRECTORY);
         if (!dir.exists()) {
-            dir.mkdirs();
+            boolean created = dir.mkdirs();
+            if (created) {
+                LOG.info("Diretório de arquivos criado em {}", dir.getAbsolutePath());
+            }
         }
     }
-    
+
+    @Override
+    public void run(String... args) {
+        LOG.info("Dependências carregadas: SessionManager={}, GroupService={}, ChatService={}",
+                sessionManager.getClass().getSimpleName(),
+                groupService.getClass().getSimpleName(),
+                chatService.getClass().getSimpleName());
+        start();
+    }
+
     public void start() {
         try {
             serverSocket = new ServerSocket(PORT);
             isRunning = true;
-            System.out.println("Servidor iniciado na porta " + PORT);
-            System.out.println("Diretório de arquivos: " + FILES_DIRECTORY);
-            
+            LOG.info("Servidor iniciado na porta {}", PORT);
+            LOG.info("Diretório de arquivos: {}", FILES_DIRECTORY);
+
             while (isRunning) {
                 try {
                     Socket clientSocket = serverSocket.accept();
-                    System.out.println("🔗 Nova conexão recebida: " + clientSocket.getInetAddress());
+                    LOG.info("🔗 Nova conexão recebida: {}", clientSocket.getInetAddress());
 
-                    ChatHandler clientHandler = new ChatHandler(clientSocket, sessionManager, chatService, groupService);
+                    ChatHandler clientHandler = chatHandlerFactory.create(clientSocket);
                     threadPool.execute(clientHandler);
-                    
+
                 } catch (IOException e) {
                     if (isRunning) {
-                        System.err.println("Erro ao aceitar conexão: " + e.getMessage());
+                        LOG.error("Erro ao aceitar conexão", e);
                     }
                 }
             }
         } catch (IOException e) {
-            System.err.println("Erro ao iniciar servidor: " + e.getMessage());
+            LOG.error("Erro ao iniciar servidor", e);
         }
     }
-    
+
+    @PreDestroy
+    public void onDestroy() {
+        stop();
+    }
+
     public void stop() {
         isRunning = false;
         try {
-            if (serverSocket != null) {
+            if (serverSocket != null && !serverSocket.isClosed()) {
                 serverSocket.close();
             }
             threadPool.shutdown();
-            System.out.println("Servidor parado");
+            LOG.info("Servidor parado");
         } catch (IOException e) {
-            System.err.println("Erro ao parar servidor: " + e.getMessage());
+            LOG.error("Erro ao parar servidor", e);
         }
     }
 
     public static void main(String[] args) {
-        SocketServerChatApplication server = new SocketServerChatApplication();
-        
-        Runtime.getRuntime().addShutdownHook(new Thread(server::stop));
-        
-        server.start();
+        SpringApplication.run(SocketServerChatApplication.class, args);
     }
 }
-

--- a/src/main/java/br/com/study/socketchat/server/group/GroupManager.java
+++ b/src/main/java/br/com/study/socketchat/server/group/GroupManager.java
@@ -1,12 +1,14 @@
 package br.com.study.socketchat.server.group;
 
 import br.com.study.socketchat.commons.Group;
+import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Component
 public class GroupManager {
     private Map<String, Group> groups;
 

--- a/src/main/java/br/com/study/socketchat/server/group/service/GroupService.java
+++ b/src/main/java/br/com/study/socketchat/server/group/service/GroupService.java
@@ -2,9 +2,11 @@ package br.com.study.socketchat.server.group.service;
 
 import br.com.study.socketchat.commons.Group;
 import br.com.study.socketchat.server.group.GroupManager;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Service
 public class GroupService {
     private final GroupManager groupManager;
 

--- a/src/main/java/br/com/study/socketchat/server/service/ChatService.java
+++ b/src/main/java/br/com/study/socketchat/server/service/ChatService.java
@@ -9,6 +9,7 @@ import br.com.study.socketchat.server.storage.OfflineMessageStorage;
 import br.com.study.socketchat.server.session.SessionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 
 import java.util.Set;
 
@@ -16,6 +17,7 @@ import java.util.Set;
  * Serviço responsável pela lógica de envio de mensagens.
  * Aplica regras de negócio do chat (online/offline, entrega, erro).
  */
+@Service
 public class ChatService {
     private static final Logger LOG = LoggerFactory.getLogger(ChatService.class);
     private static final String SERVER_USER = "SERVER";
@@ -42,7 +44,7 @@ public class ChatService {
      */
     public void sendGroupMessage(Message message, ChatHandler sender) {
         String groupName = message.getTo();
-        Group group = groupService.findGroupWithUser(message.getFrom(), groupName);
+        Group group = groupService.findGroupWithUser(groupName, message.getFrom());
 
         if (group == null) {
             sender.sendGenericMessage(buildErrorMessage(message, "Grupo não existe: " + groupName));

--- a/src/main/java/br/com/study/socketchat/server/session/SessionManager.java
+++ b/src/main/java/br/com/study/socketchat/server/session/SessionManager.java
@@ -4,12 +4,14 @@ import br.com.study.socketchat.commons.User;
 import br.com.study.socketchat.server.ChatHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Component
 public class SessionManager {
     private static final Logger LOG = LoggerFactory.getLogger(SessionManager.class);
 


### PR DESCRIPTION
## Summary
- correct the group lookup so chat handlers can deliver group messages with the Spring-managed services
- ensure group listing replies use the proper message type for clients to consume
- add a comprehensive README describing the architecture, local/docker execution, and testing instructions

## Testing
- ./mvnw clean package *(fails: offline environment cannot download Maven wrapper binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68d008a96c2c83339279cdecc809f3c3